### PR TITLE
Change Deployment to StatefulSet

### DIFF
--- a/charts/livy/Chart.yaml
+++ b/charts/livy/Chart.yaml
@@ -10,6 +10,6 @@ maintainers:
 - email: jahstreetlove@gmail.com
   name: Aliaksandr Sasnouskikh
 name: livy
-version: 0.3.2
+version: 0.4.0
 sources:
 - https://github.com/jahstreet/incubator-livy/tree/v0.6.0-incubating-kubernetes-support

--- a/charts/livy/README.md
+++ b/charts/livy/README.md
@@ -11,7 +11,6 @@ Note that the default image `sasnouskikh/livy:0.7.0-incubating-spark_2.4.3_2.11-
 
 | Parameter                            | Description                                                      |Default                                                                                                                         |
 | ------------------------------------ |----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| strategy | Kubernetes Deployment update strategy spec | `{}` |
 | image.repository | Repository for Livy | `sasnouskikh/livy` |
 | image.tag | Tag for Livy | `0.7.0-incubating-spark_2.4.3_2.11-hadoop_3.2.0` |
 | image.pullPolicy | Pull policy for Livy | `IfNotPresent` |
@@ -24,7 +23,6 @@ Note that the default image `sasnouskikh/livy:0.7.0-incubating-spark_2.4.3_2.11-
 | sparkServiceAccount.name | The name of the ServiceAccount to use for Spark. If not set and `create` is true, a name is generated using the `livy.fullname` template with `-spark` suffix| `""` |
 | service.type | Livy Service type | `ClusterIP` |
 | service.port | Livy Service port | `80` |
-| service.additionalPorts | Livy Service additional ports | `[]` |
 | ingress.enabled | Whether to create Ingress resource for Livy Service | `false` |
 | ingress.annotations | Ingress annotations | `{}` |
 | ingress.path | Ingress path | `/` |

--- a/charts/livy/templates/NOTES.txt
+++ b/charts/livy/templates/NOTES.txt
@@ -1,9 +1,6 @@
 The Livy server has been installed.
 Check its status by running:
   kubectl --namespace {{ .Release.Namespace }} get pods -l "app.kubernetes.io/instance={{ .Release.Name }}"
-{{- if not .Values.ingress.enabled }}
-  # Save Livy Pod name to `LIVY_POD_NAME` variable
-{{- end }}
 Connect to the Livy Web UI:
 {{- if .Values.ingress.enabled }}
     # Be sure to set .Values.ingress.path relevant to .Values.env.LIVY_LIVY_UI_BASE1PATH.value
@@ -12,7 +9,7 @@ Connect to the Livy Web UI:
     #   {{ . }}{{ $.Values.env.LIVY_LIVY_UI_BASE1PATH.value }}
     {{- end }}
 {{- else }}
-    kubectl --namespace {{ .Release.Namespace }} port-forward $LIVY_POD_NAME 8998"
+    kubectl --namespace {{ .Release.Namespace }} port-forward {{ include "livy.fullname" . }}-0 8998"
     # Open in browser: http://localhost:8998
 {{- end }}
 

--- a/charts/livy/templates/headless-service.yaml
+++ b/charts/livy/templates/headless-service.yaml
@@ -1,14 +1,15 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "livy.fullname" . }}
+  name: {{ include "livy.fullname" . }}-headless
   labels:
     app.kubernetes.io/name: {{ include "livy.name" . }}
     helm.sh/chart: {{ include "livy.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  type: {{ .Values.service.type }}
+  type: ClusterIP
+  clusterIP: None
   ports:
   - port: {{ .Values.service.port }}
     targetPort: http

--- a/charts/livy/templates/service-headless.yaml
+++ b/charts/livy/templates/service-headless.yaml
@@ -10,11 +10,6 @@ metadata:
 spec:
   type: ClusterIP
   clusterIP: None
-  ports:
-  - port: {{ .Values.service.port }}
-    targetPort: http
-    protocol: TCP
-    name: http
   selector:
     app.kubernetes.io/name: {{ include "livy.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/livy/templates/statefulset.yaml
+++ b/charts/livy/templates/statefulset.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1beta2
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: {{ include "livy.fullname" . }}
   labels:
@@ -8,8 +8,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  strategy:
-    {{- toYaml .Values.strategy | nindent 4 }}
+  serviceName: {{ include "livy.fullname" . }}-headless
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "livy.name" . }}
@@ -29,13 +28,6 @@ spec:
         - name: http
           containerPort: 8998
           protocol: TCP
-        {{- if .Values.service.additionalPorts }}
-        {{- range .Values.service.additionalPorts }}
-        - name: {{ .name }}
-          containerPort: {{ .port }}
-          protocol: TCP
-        {{- end }}
-        {{- end }}
         livenessProbe:
           httpGet:
             path: /batches
@@ -47,8 +39,6 @@ spec:
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
         env:
-        - name: LIVY_CLIENT_RSC_RPC_SERVER_ADDRESS
-          value: {{ include "livy.fullname" . }}.{{ .Release.Namespace }}.svc
         {{- if .Values.rbac.create }}
         - name: LIVY_SPARK_KUBERNETES_AUTHENTICATE_DRIVER_SERVICE1ACCOUNT1NAME
           value: {{ include "livy.fullname" . }}-spark

--- a/charts/livy/values.yaml
+++ b/charts/livy/values.yaml
@@ -4,12 +4,6 @@
 
 global: {}
 
-strategy: {}
-  # type: RollingUpdate
-  # rollingUpdate:
-  #   maxSurge: 0
-  #   maxUnavailable: 1
-
 image:
   repository: sasnouskikh/livy
   tag: 0.7.0-incubating-spark_2.4.3_2.11-hadoop_3.2.0

--- a/charts/livy/values.yaml
+++ b/charts/livy/values.yaml
@@ -38,9 +38,6 @@ sparkServiceAccount:
 service:
   type: ClusterIP
   port: 80
-  additionalPorts: []
-  #  - name: rpc10000
-  #    port: 10000
 
 ingress:
   enabled: false

--- a/charts/spark-cluster/Chart.yaml
+++ b/charts/spark-cluster/Chart.yaml
@@ -10,4 +10,4 @@ maintainers:
 - email: jahstreetlove@gmail.com
   name: Aliaksandr Sasnouskikh
 name: spark-cluster
-version: 0.5.1
+version: 0.6.0

--- a/charts/spark-cluster/requirements.lock
+++ b/charts/spark-cluster/requirements.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: livy
   repository: file://../livy
-  version: 0.3.2
+  version: 0.4.0
 - name: spark-history-server
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 0.5.0
 - name: jupyterhub
   repository: https://jupyterhub.github.io/helm-chart
   version: 0.9-fe7b5df
-digest: sha256:04d974a8c5f30d53a128584dc9dc20c9dd1125ea95ee4ff33cd60ab3818fe81e
-generated: 2019-07-08T06:28:05.223537179-04:00
+digest: sha256:9cad16a56a7ad303c407658951d790c090024ee8b5f43f7e1c7cf1d4e57ca5bc
+generated: "2019-08-29T11:03:38.040245+02:00"

--- a/charts/spark-cluster/requirements.yaml
+++ b/charts/spark-cluster/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 
 - name: livy
-  version: "0.3.*"
+  version: "0.4.*"
   # repository: "https://jahstreet.github.io/helm-charts"
   repository: "file://../livy"
   condition: livy.enabled,global.livy.enabled
@@ -19,6 +19,6 @@ dependencies:
 - name: jupyterhub
   version: "0.9-fe7b5df"
   repository: "https://jupyterhub.github.io/helm-chart"
-  condition: historyserver.enabled,global.historyserver.enabled
+  condition: jupyterhub.enabled,global.jupyterhub.enabled
   tags:
   - jupyterhub

--- a/charts/spark-cluster/values.yaml
+++ b/charts/spark-cluster/values.yaml
@@ -12,37 +12,8 @@ fullnameOverride: ""
 
 livy:
   
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 0
-      maxUnavailable: 1
-  
   rbac:
     create: true
-  
-  service:
-    additionalPorts: # Expose ports for Interactvie Sessions RPC servers
-    - name: rpc10000
-      port: 10000
-    - name: rpc10001
-      port: 10001
-    - name: rpc10002
-      port: 10002
-    - name: rpc10003
-      port: 10003
-    - name: rpc10004
-      port: 10004
-    - name: rpc10005
-      port: 10005
-    - name: rpc10006
-      port: 10006
-    - name: rpc10007
-      port: 10007
-    - name: rpc10008
-      port: 10008
-    - name: rpc10009
-      port: 10009
   
   ingress:
     enabled: false
@@ -330,7 +301,7 @@ jupyterhub:
       #   readOnly: false
     
     image:
-      repository: sasnouskikh/jupyter
+      name: sasnouskikh/jupyter
       tag: 4.4.0-sparkmagic_0.12.9
       pullPolicy: IfNotPresent
 


### PR DESCRIPTION
- Change Deployment to StatefulSet;
- Add Headless Service as it is [required](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#limitations) for the StatefulSet
- Remove aditional ports from helm values, statefulset and service templates