### PR TITLE
Use correct service name in livy ingress

### DIFF
--- a/charts/livy/templates/ingress.yaml
+++ b/charts/livy/templates/ingress.yaml
@@ -30,7 +30,7 @@ spec:
         paths:
           - path: {{ $.Values.ingress.path }}
             backend:
-              serviceName: {{ include "livy.fullname" $ }}
+              serviceName: {{ default (include "livy.fullname" $) $.Values.service.name }}
               servicePort: http
   {{- end }}
 {{- end }}


### PR DESCRIPTION
When I deployed the spark-cluster helm chart, I noticed the ingress config does not work. This is because the spark cluster helm chart changes the livy service name. However, in the ingress template of the livy chart, the configured value is not used. I fixed it by using the same function that is used in the service to generate the name there. 