### PR TITLE
Ugrade jupyterhub helm chart to version 0.11.1

### DIFF
--- a/charts/spark-cluster/requirements.lock
+++ b/charts/spark-cluster/requirements.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 1.4.3
 - name: jupyterhub
   repository: https://jupyterhub.github.io/helm-chart
-  version: 0.9.1
-digest: sha256:9b73a12e4181e978d3ffc7d20fc84a2c19cdaebf1e9e8ed7f2b8949cc5901149
-generated: "2020-12-19T10:42:21.020929+03:00"
+  version: 0.11.1
+digest: sha256:6c60d3f73fcee796508ab83f4c0184f0ea6aa8e9e5bc99a840bcacb58b9fccc2
+generated: "2021-01-15T15:19:50.2832102+01:00"

--- a/charts/spark-cluster/requirements.yaml
+++ b/charts/spark-cluster/requirements.yaml
@@ -17,7 +17,7 @@ dependencies:
   alias: historyserver
 
 - name: jupyterhub
-  version: "0.9.*"
+  version: "0.11.*"
   repository: "https://jupyterhub.github.io/helm-chart"
   condition: jupyterhub.enabled,global.jupyterhub.enabled
   tags:

--- a/charts/spark-cluster/values.yaml
+++ b/charts/spark-cluster/values.yaml
@@ -221,6 +221,18 @@ jupyterhub:
     #   enabled: true
     #   minAvailable: 0
 
+    # Authentication configuration
+    config:
+      Authenticator:
+        admin_users:
+          - admin
+        allowed_users:
+          - user1
+      DummyAuthenticator:
+        password: admin
+      JupyterHub:
+        authenticator_class: dummy
+
   proxy:
 
     https:
@@ -247,30 +259,6 @@ jupyterhub:
     #   enabled: true
     #   minAvailable: 0
 
-  auth:
-
-    # Azure AD OAuthenticator
-    # type: custom
-    # custom:
-    #   className: oauthenticator.azuread.AzureAdOAuthenticator
-    #   config:
-    #     oauth_callback_url: 'https://{your-domain}/{jupyterhub-base-path}/hub/oauth_callback'
-    #     client_id: '{AAD-APP-CLIENT-ID}'
-    #     client_secret: '{AAD-APP-CLIENT-SECRET}'
-    #     # https://github.com/jupyterhub/oauthenticator/issues/218
-    #     tenant_id: "{AAD-TENANT-ID}"
-    # NOTE: do not forget to set `AAD_TENANT_ID` env var above
-
-    type: dummy
-    whitelist:
-      users:
-      - admin
-    admin:
-      access: true
-      users:
-      - admin
-    dummy:
-      password: admin
 
   singleuser:
     startTimeout: 600


### PR DESCRIPTION
This PR upgrade the jupyterhub helm chart to version 0.11.1. As far as the tests on my setup showed, only the authentication configuration needed to be changed. I updated the dummy authentication stuff (fyi, I added an admin and a normal user to be able to test both). 

However, I have no setup to test the Azure AD OAuthenticator that you had in your values.yaml as an example. @jahstreet: Maybe you can test and add that again. 