### PR TITLE
feat: support livy chart's volumes and volumeMounts

### DIFF
--- a/charts/livy/Chart.yaml
+++ b/charts/livy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: livy
-version: 2.0.1
+version: 2.0.2
 appVersion: v0.8.0-incubating-SNAPSHOT
 home: https://livy.incubator.apache.org/
 description: Apache Livy server to run Spark on Kubernetes

--- a/charts/livy/templates/statefulset.yaml
+++ b/charts/livy/templates/statefulset.yaml
@@ -56,6 +56,9 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
         volumeMounts:
+        {{- with .Values.volumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- if .Values.persistence.enabled }}
         - name: livy-store
           mountPath: /tmp/livy/store
@@ -76,6 +79,9 @@ spec:
         - name: spark-defaults-conf-secret
           mountPath: /etc/secret/spark-defaults.conf
       volumes:
+      {{- with .Values.volumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       - name: livy-store
         {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:

--- a/charts/livy/values.yaml
+++ b/charts/livy/values.yaml
@@ -109,6 +109,12 @@ persistence:
   size: 20Gi
   annotations: {}
 
+# volumes - Livy volumes
+volumes: []
+
+# volumeMounts - Livy volumeMounts
+volumeMounts: []
+
 env:
   LIVY_LIVY_UI_BASE1PATH: {value: ""} # eg.: `/livy`
   LIVY_LIVY_SERVER_SESSION_STATE0RETAIN_SEC: {value: "12h"}


### PR DESCRIPTION
Because of various reasons like external jar cache volume, it is needed for livy chart  to support volumes and volumeMounts.