### PR TITLE
Updated README.md to use correct example jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ kubectl exec --namespace livy livy-0 -- \
             "name": "SparkPi-01",
             "className": "org.apache.spark.examples.SparkPi",
             "numExecutors": 2,
-            "file": "local:///opt/spark/examples/jars/spark-examples_2.11-2.4.5.jar",
+            "file": "local:///opt/spark/examples/jars/spark-examples_2.12-3.0.1.jar",
             "args": ["10000"],
             "conf": {
                 "spark.kubernetes.namespace": "livy"


### PR DESCRIPTION
I tried to perform the steps in the README.md and noticed, that it seems to be outdated. The jar referenced in the batch job submitted to Livy is actually not contained in the spark base image. So I updated it.